### PR TITLE
Fix debug output, sensor noise, and defensive improvements

### DIFF
--- a/MazeRobot/MazeRobot.ino
+++ b/MazeRobot/MazeRobot.ino
@@ -388,9 +388,9 @@ void motorInit(const Motor* m) {
 void motorSet(const Motor* m, int speed) {
   int adjustedSpeed;
   if (speed > 0) {
-    adjustedSpeed = constrain(speed + m->trim, -255, 255);
+    adjustedSpeed = constrain(speed + m->trim, 1, 255);
   } else if (speed < 0) {
-    adjustedSpeed = constrain(speed - m->trim, -255, 255);
+    adjustedSpeed = constrain(speed - m->trim, -255, -1);
   } else {
     adjustedSpeed = 0;
   }
@@ -580,7 +580,7 @@ RobotState returnState;     // State to resume after turn completes
 // Updated every loop iteration by readIRSensors() and readUltrasonicSensors().
 int irRaw[4];               // Raw analog readings (0-1023) from IR sensors
 bool irOnLine[4];           // Processed: true if sensor i detects the line
-float dist[3];              // Ultrasonic distances: [0]=front, [1]=left, [2]=right (cm)
+float dist[3] = { MAX_DISTANCE, MAX_DISTANCE, MAX_DISTANCE }; // Ultrasonic distances: [0]=front, [1]=left, [2]=right (cm)
 float distFiltered[3] = { MAX_DISTANCE, MAX_DISTANCE, MAX_DISTANCE }; // EMA-smoothed distances
 
 // --- Wall Following State ---
@@ -697,7 +697,7 @@ void startBackupAndTurn(TurnDir dir, RobotState afterState) {
 //   4. Set IR_LINE_THRESHOLD halfway between those two values
 //   5. Set IR_HIGH_ON_LINE based on which reading was higher
 void readIRSensors() {
-  const int irPins[] = { PIN_IR1, PIN_IR2, PIN_IR3, PIN_IR4 };
+  static const int irPins[] = { PIN_IR1, PIN_IR2, PIN_IR3, PIN_IR4 };
   for (int i = 0; i < 4; i++) {
     irRaw[i] = analogRead(irPins[i]);
     if (IR_HIGH_ON_LINE) {
@@ -723,7 +723,7 @@ void readUltrasonicSensors() {
   // Read one sensor per call to reduce blocking time (~30ms vs ~90ms)
   // and prevent echo crosstalk between adjacent sensors.
   static uint8_t sensorIndex = 0;
-  NewPing* sonars[] = { &sonarFront, &sonarLeft, &sonarRight };
+  static NewPing* const sonars[] = { &sonarFront, &sonarLeft, &sonarRight };
 
   float raw = sonars[sensorIndex]->ping_cm();
   dist[sensorIndex] = (raw == 0) ? MAX_DISTANCE : raw;
@@ -827,8 +827,11 @@ void followLine() {
   #ifdef DEBUG
     static unsigned long lastLinePrint = 0;
     if (millis() - lastLinePrint > 200) {
-      DEBUG_PRINTF("LINE pos=%.1f err=%.1f out=%.0f L=%d R=%d\n",
-                   pos, error, output, leftSpeed, rightSpeed);
+      Serial.print("LINE pos="); Serial.print(pos, 1);
+      Serial.print(" err=");     Serial.print(error, 1);
+      Serial.print(" out=");     Serial.print(output, 0);
+      Serial.print(" L=");      Serial.print(leftSpeed);
+      Serial.print(" R=");      Serial.println(rightSpeed);
       lastLinePrint = millis();
     }
   #endif
@@ -890,7 +893,7 @@ void followWall() {
   // --- Step 2: Front obstacle avoidance ---
   // If a wall is directly ahead and too close, back up first
   // (to create clearance) then turn away from the followed wall.
-  if (dist[0] < FRONT_OBSTACLE_DIST) {
+  if (distFiltered[0] < FRONT_OBSTACLE_DIST) {
     // Turn away from the wall we're following:
     //   Following right wall -> turn left (away from right)
     //   Following left wall  -> turn right (away from left)
@@ -967,9 +970,12 @@ void followWall() {
   #ifdef DEBUG
     static unsigned long lastWallPrint = 0;
     if (millis() - lastWallPrint > 200) {
-      DEBUG_PRINTF("WALL %s d=%.0f err=%.1f out=%.0f L=%d R=%d\n",
-                   followRightWall ? "R" : "L",
-                   wallDist, error, output, leftSpeed, rightSpeed);
+      Serial.print("WALL ");    Serial.print(followRightWall ? "R" : "L");
+      Serial.print(" d=");      Serial.print(wallDist, 0);
+      Serial.print(" err=");    Serial.print(error, 1);
+      Serial.print(" out=");    Serial.print(output, 0);
+      Serial.print(" L=");      Serial.print(leftSpeed);
+      Serial.print(" R=");      Serial.println(rightSpeed);
       lastWallPrint = millis();
     }
   #endif


### PR DESCRIPTION
## Summary

- **Fix broken debug output**: Replace DEBUG_PRINTF calls using %f with chained Serial.print() calls. AVR snprintf does not support %f, so line-following and wall-following debug output was silently printing garbage.
- **Fix false front-obstacle triggers**: Use distFiltered[0] instead of raw dist[0] for the front obstacle check, preventing a single noisy 0 cm spike from triggering a backup-and-turn.
- **Initialize dist[] to MAX_DISTANCE**: Prevents the first 3 loop iterations from seeing phantom 0 cm walls before round-robin sensor reads populate all slots.
- **Make irPins[] and sonars[] static const**: Avoids rebuilding these constant arrays on the stack every loop() iteration.
- **Clamp trim to preserve motor direction**: motorSet() now constrains adjusted speed to [1, 255] (positive) or [-255, -1] (negative), so trim can never flip a motor direction. The speed == 0 coast path is unchanged.

## Test plan

- [x] Compiles cleanly with arduino-cli compile --fqbn arduino:avr:mega (12,098 bytes flash, 760 bytes RAM)
- [ ] Verify debug serial output prints readable float values for LINE and WALL modes
- [ ] Confirm front obstacle avoidance no longer false-triggers on sensor noise
- [ ] Confirm driveStop() still coasts (speed=0 branch unchanged by trim clamping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved motor speed control to operate within valid ranges
  * Enhanced distance sensor initialization and filtering for more reliable obstacle detection
  * Refined wall-following logic to use filtered sensor data for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->