### PR TITLE
Add compile check and Claude PR review workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: Build
+
+# Compiles the sketch for the Arduino Mega 2560 on every PR and every push to
+# main. This is the only mechanical check the project has -- there are no unit
+# tests, since the code is a single sketch that talks directly to hardware.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: Compile (Arduino Mega 2560)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AVR_CORE_VERSION: 1.8.7
+      NEWPING_VERSION: 1.9.7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install arduino-cli
+        uses: arduino/setup-arduino-cli@v2
+
+      # The AVR core is a ~200 MB download. Cache it against the pinned
+      # versions so a normal run only pays for the compile itself.
+      - name: Cache Arduino cores and libraries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.arduino15
+            ~/Arduino/libraries
+          key: arduino-avr-${{ env.AVR_CORE_VERSION }}-newping-${{ env.NEWPING_VERSION }}
+
+      - name: Install AVR core and NewPing
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install "arduino:avr@${AVR_CORE_VERSION}"
+          arduino-cli lib install "NewPing@${NEWPING_VERSION}"
+
+      # Human-readable pass: compiler errors and warnings land in the run log.
+      # The sketch itself is clean under --warnings all; the only warnings you
+      # should see come from the Arduino core's own new.cpp.
+      - name: Compile sketch
+        run: |
+          arduino-cli compile \
+            --fqbn arduino:avr:mega \
+            --warnings all \
+            MazeRobot
+
+      # Second pass for the size numbers only. arduino-cli reuses its build
+      # cache, so this re-run is effectively free.
+      - name: Collect size data
+        run: |
+          arduino-cli compile \
+            --fqbn arduino:avr:mega \
+            --json \
+            MazeRobot > compile.json
+
+      # The Mega has 8 KB of SRAM and the sketch keeps every buffer static, so
+      # a jump in the `data` segment is the failure mode worth watching. Put
+      # both segments on the run summary instead of burying them in the log.
+      - name: Report flash and SRAM usage
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+
+          sections = json.loads(pathlib.Path("compile.json").read_text())[
+              "builder_result"
+          ]["executable_sections_size"]
+          labels = {"text": "Flash (program storage)", "data": "SRAM (global variables)"}
+
+          print("### Size report -- Arduino Mega 2560\n")
+          print("| Segment | Used | Max | Percent |")
+          print("| --- | ---: | ---: | ---: |")
+          for s in sections:
+              pct = 100.0 * s["size"] / s["max_size"]
+              print(
+                  f"| {labels.get(s['name'], s['name'])} "
+                  f"| {s['size']:,} B | {s['max_size']:,} B | {pct:.1f}% |"
+              )
+          PY

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,131 @@
+name: Claude Review
+
+# Reviews every non-draft PR against main. The review prompt is written for
+# this repo specifically -- a single AVR sketch with no test harness -- so it
+# looks for embedded failure modes (SRAM, millis() rollover, 16-bit int math,
+# blocking calls) rather than the generic web-app checklist.
+#
+# Two setup steps are required before this runs:
+#   1. Install the Claude GitHub App: https://github.com/apps/claude
+#   2. Add the CLAUDE_CODE_OAUTH_TOKEN secret (from `claude setup-token`)
+#
+# Note there is deliberately no `github_token:` input. The action authenticates
+# to GitHub through the Claude App using the OIDC token, which is why this job
+# needs `id-token: write`. Passing github_token is only correct when running a
+# custom GitHub App of your own, and doing so makes comments post under the
+# wrong identity.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review PR
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read # lets Claude read the Build workflow's result
+    steps:
+      # `secrets` is not available in a job-level `if`, so gate on a step
+      # instead. Until the secret exists this surfaces a warning annotation
+      # rather than a red X on every PR.
+      - name: Check for Claude credentials
+        id: preflight
+        env:
+          CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$CLAUDE_TOKEN" ]; then
+            echo "::warning title=Claude review skipped::Secret CLAUDE_CODE_OAUTH_TOKEN is not set. Run 'claude setup-token' locally, add the result under Settings > Secrets and variables > Actions, and install the Claude GitHub App at https://github.com/apps/claude."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.preflight.outputs.configured == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Review
+        if: steps.preflight.outputs.configured == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. The project is a maze-solving robot: one
+            monolithic Arduino sketch (MazeRobot/MazeRobot.ino) targeting an
+            Arduino Mega 2560 (ATmega2560, 8 KB SRAM, 256 KB flash, 16-bit int).
+            Read CLAUDE.md and docs/ARCHITECTURE.md before reviewing.
+
+            Focus on the failure modes that actually bite this codebase:
+
+            1. Real-time behavior. loop() must stay under ~50 ms and must never
+               block during navigation. Flag any delay(), busy-wait, or long
+               while-loop added to a path reachable from loop().
+
+            2. millis() rollover. Timer arithmetic must be unsigned subtraction
+               (`now - start >= interval`). Flag any `start + interval <= now`
+               form, or a timestamp stored in a signed or too-narrow type.
+
+            3. SRAM. Globals already use ~14% of 8 KB. Flag new large globals or
+               arrays, string literals not wrapped in F(), snprintf stack
+               buffers over 120 bytes, and any dynamic allocation (malloc, new,
+               or the String class) -- the project forbids all three.
+
+            4. AVR libc limits. snprintf on AVR does not support %f. Float
+               output must go through dtostrf() or an integer cast.
+
+            5. 16-bit int. On AVR `int` is 16 bits. Flag arithmetic that can
+               exceed +/-32767 -- multiplied analogRead values, PID terms,
+               accumulated error, millis() results assigned to int.
+
+            6. Convention: every tunable constant belongs in Section 3 of the
+               sketch. Flag magic numbers introduced anywhere else.
+
+            7. Motor encoding: positive speed = forward, negative = backward,
+               zero = coast. Trim offsets must be clamped in a way that
+               preserves sign, and the result must stay in valid PWM range.
+
+            8. PID: check both anti-windup layers (integral clamping AND
+               conditional integration), and that the line and wall controllers
+               stay isolated and get reset across mode transitions.
+
+            9. State machine: every transition must set up whatever the target
+               state assumes. Check that ERROR_STATE and EXIT_FOUND stay
+               terminal and that no state becomes unreachable.
+
+            10. Sensor scheduling: the front ultrasonic reads every cycle, but
+                left and right alternate. Flag code that assumes both side
+                distances were refreshed in the same cycle. Check EMA filter
+                initialization and IR array bounds (4 sensors, A0-A3).
+
+            The Build workflow compiles the sketch on this PR. Check its result
+            with `gh run list` if it has finished; if it is still running, say
+            so rather than guessing.
+
+            Scope notes:
+            - This is firmware. Do NOT raise web-application concerns (SQL
+              injection, XSS, authentication, API design).
+            - There is no test harness and no unit tests are expected. Do not
+              ask for them. Verification is compile + physical testing.
+            - Comment only on real problems. Use inline comments for specific
+              lines and one top-level comment for the summary. If the change
+              looks correct, say that plainly instead of manufacturing
+              findings.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.1](https://github.com/stephennmiller/Mechatronics-Project/releases/tag/v1.4.1) - 2026-08-11 ([#38](https://github.com/stephennmiller/Mechatronics-Project/pull/38))
+
+### Added
+
+- `.github/workflows/build.yml` — compiles the sketch for `arduino:avr:mega` with `--warnings all` on every PR and push to `main`, and posts a flash/SRAM size table to the run summary
+- `.github/workflows/claude-review.yml` — automated Claude review of every non-draft PR, prompted for embedded failure modes (SRAM pressure, `millis()` rollover, 16-bit `int` overflow, blocking calls in `loop()`) rather than a generic web-app checklist
+- CI setup instructions in README and `CLAUDE.md`
+
 ## [v1.4.0](https://github.com/stephennmiller/Mechatronics-Project/releases/tag/v1.4.0) - 2026-02-23 ([#37](https://github.com/stephennmiller/Mechatronics-Project/pull/37))
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,13 @@ Arduino Mega 2560-based maze-solving robot for UCF Mechatronics course. Solves a
 - **Board:** Arduino Mega 2560
 - **Library dependency:** NewPing (install via Arduino Library Manager)
 - **Serial monitor:** 115200 baud for debug output
-- **No automated tests or CI** — verification is done via serial debug output and physical testing
+- **No unit tests** — behavior is verified via serial debug output and physical testing
+- **CI:** `.github/workflows/build.yml` compiles the sketch for `arduino:avr:mega` on every PR and reports flash/SRAM usage. Reproduce locally with:
+  ```
+  arduino-cli compile --fqbn arduino:avr:mega --warnings all MazeRobot
+  ```
+  A green build means it compiles, nothing more — it does not exercise any robot behavior.
+- **PR review:** `.github/workflows/claude-review.yml` runs Claude on every non-draft PR. Requires both the [Claude GitHub App](https://github.com/apps/claude) installed on the repo and a `CLAUDE_CODE_OAUTH_TOKEN` secret; without the secret the job emits a warning and skips.
 
 ## Code Architecture
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ This project implements a maze-solving robot using an Arduino Mega 2560. The rob
 2. Install the NewPing library in the Arduino IDE.
 3. Upload `MazeRobot.ino` to your Arduino Mega.
 
+## Continuous Integration
+
+Two GitHub Actions workflows run on every pull request:
+
+| Workflow | What it does |
+| --- | --- |
+| `Build` | Compiles the sketch for `arduino:avr:mega` with `--warnings all` and posts flash/SRAM usage to the run summary. |
+| `Claude Review` | Reviews the diff for embedded-specific problems — SRAM pressure, `millis()` rollover, 16-bit `int` overflow, blocking calls in `loop()`. |
+
+A green `Build` means the sketch compiles; it does not verify any robot behavior. That still requires the hardware.
+
+To run the same compile locally:
+
+```
+arduino-cli core install arduino:avr@1.8.7
+arduino-cli lib install NewPing@1.9.7
+arduino-cli compile --fqbn arduino:avr:mega --warnings all MazeRobot
+```
+
+### Enabling `Claude Review`
+
+Two one-time setup steps, both required:
+
+1. Install the [Claude GitHub App](https://github.com/apps/claude) on this repository. The action authenticates to GitHub through the app, so the workflow fails without it.
+2. Generate a token with `claude setup-token` and save it as a repository secret named `CLAUDE_CODE_OAUTH_TOKEN` (Settings > Secrets and variables > Actions).
+
+Until the secret exists the job logs a warning and skips rather than failing the PR. `Build` needs no setup and runs immediately.
+
 ## Calibration
 
 ### IR Auto-Calibration (at startup)


### PR DESCRIPTION
Adds the first CI this repo has had. Two workflows, plus the doc updates they make necessary.

## `build.yml` — compile check

Compiles `MazeRobot` for `arduino:avr:mega` with `--warnings all` on every PR and push to `main`, then posts a size table to the run summary:

| Segment | Used | Max | Percent |
| --- | ---: | ---: | ---: |
| Flash (program storage) | 15,828 B | 253,952 B | 6.2% |
| SRAM (global variables) | 1,156 B | 8,192 B | 14.1% |

The size report matters as much as pass/fail. The Mega has 8 KB of SRAM, globals already use 14% of it, and the sketch keeps every buffer static — growth in the `data` segment is the failure mode that ends a run on hardware. `arduino:avr@1.8.7` and `NewPing@1.9.7` are pinned and cached.

## `claude-review.yml` — automated PR review

Reviews non-draft PRs with `track_progress` enabled. The prompt is written against this codebase rather than a generic checklist: 16-bit `int` overflow, `millis()` rollover, `snprintf`'s missing `%f` on AVR, blocking calls reachable from `loop()`, PID anti-windup, the alternating left/right ultrasonic schedule, and the Section 3 constants convention. It explicitly rules out web-app findings and requests for unit tests — neither applies to a single sketch that drives hardware.

Two implementation notes:

- The credential check is a **step**, not a job-level `if`, because the `secrets` context is not available in `jobs.<job_id>.if` (confirmed against GitHub's context-availability table). Without the secret the job emits a warning annotation and skips rather than red-X'ing every PR.
- No `github_token` is passed. The action authenticates through the Claude GitHub App via OIDC — hence `id-token: write`. Per the action's docs, supplying `github_token` is only correct for a custom app and otherwise makes comments post under the wrong identity.

## Required before the review workflow runs

Both are needed, not just the secret:

1. Install the [Claude GitHub App](https://github.com/apps/claude) on this repository.
2. `claude setup-token`, then save the result as the `CLAUDE_CODE_OAUTH_TOKEN` repository secret.

`build.yml` needs no setup and runs on this PR.

## Verification

- Sketch compiles clean for the Mega — zero warnings originating in `MazeRobot.ino` under `--warnings all`; the only warnings come from the Arduino core's own `new.cpp`.
- Ran the workflow's exact install sequence from empty `ARDUINO_DIRECTORIES_*` to simulate a cold runner: exit 0. `lib install` works without a prior `lib update-index`.
- Ran the size-report script against real `--json` output; it produces the table above.
- Both workflow files parse as YAML.

Neither workflow has been observed executing on GitHub — this PR is the first run.

## Reviewer notes

- The review prompt encodes opinions about this project worth checking before merge.
- Changelog is tagged `v1.4.1` with the `#38` link, matching the `v1.4.0` header format. Patch rather than minor because the sketch is byte-identical — this adds no firmware behavior.
- Commit subject uses this repo's sentence-case style rather than Conventional Commits, matching existing history.
